### PR TITLE
Make processing of TXT files with >= 255 dimensions work

### DIFF
--- a/evaluation_framework/SemanticAnalogies/semanticAnalogies_taskManager.py
+++ b/evaluation_framework/SemanticAnalogies/semanticAnalogies_taskManager.py
@@ -60,7 +60,7 @@ class SemanticAnalogiesManager (AbstractTaskManager):
         for gold_standard_filename in gold_standard_filenames:
             script_dir = os.path.dirname(__file__)
             rel_path = "data/"+gold_standard_filename+'.txt'
-            gold_standard_file = Path(os.path.join(script_dir, rel_path))
+            gold_standard_file = str(Path(os.path.join(script_dir, rel_path)))
             
             data, ignored = self.data_manager.intersect_vectors_goldStandard(vectors, vector_file, vector_size, gold_standard_file)
             self.storeIgnored(results_folder, gold_standard_filename, ignored)

--- a/evaluation_framework/txt_dataManager.py
+++ b/evaluation_framework/txt_dataManager.py
@@ -151,7 +151,7 @@ class ClassificationDataManager(DataManager):
 
         merged = pd.merge(gold, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(gold, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][gold.columns]
 
         return merged, ignored                                            
 """
@@ -198,7 +198,7 @@ class ClusteringDataManager(DataManager):
 
         merged = pd.merge(gold, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(gold, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][gold.columns]
 
         return merged, ignored
 """
@@ -241,7 +241,7 @@ class DocumentSimilarityDataManager(DataManager):
         entities = self.get_entities(goldStandard_filename)
         merged = pd.merge(entities, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(entities, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][entities.columns]
 
         return merged, ignored
 
@@ -382,7 +382,7 @@ class RegressionDataManager(DataManager):
 
         merged = pd.merge(gold, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(gold, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][gold.columns]
 
         return merged, ignored
     

--- a/evaluation_framework/txt_dataManager.py
+++ b/evaluation_framework/txt_dataManager.py
@@ -151,7 +151,7 @@ class ClassificationDataManager(DataManager):
 
         merged = pd.merge(gold, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(gold, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only']
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
 
         return merged, ignored                                            
 """
@@ -198,7 +198,7 @@ class ClusteringDataManager(DataManager):
 
         merged = pd.merge(gold, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(gold, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only']
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
 
         return merged, ignored
 """
@@ -241,7 +241,7 @@ class DocumentSimilarityDataManager(DataManager):
         entities = self.get_entities(goldStandard_filename)
         merged = pd.merge(entities, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(entities, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only']
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
 
         return merged, ignored
 
@@ -334,7 +334,7 @@ class EntityRelatednessDataManager(DataManager):
         
         merged = pd.merge(goldStandard_data, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(goldStandard_data, vectors, on='name', how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge']=='left_only']
+        ignored = outputLeftMerge[outputLeftMerge['_merge']=='left_only'][goldStandard_data.columns]
         
         return merged, ignored
     
@@ -382,7 +382,7 @@ class RegressionDataManager(DataManager):
 
         merged = pd.merge(gold, vectors, on='name', how='inner')
         outputLeftMerge = pd.merge(gold, vectors, how='outer', indicator=True)
-        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only']
+        ignored = outputLeftMerge[outputLeftMerge['_merge'] == 'left_only'][goldStandard_data]
 
         return merged, ignored
     


### PR DESCRIPTION
When iterating over a DataFrame object with more than 254 columns, the `itertuples()` function returns plain `tuple` objects instead of `namedtuple`s (see [documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.itertuples.html)), which breaks the code when elements of the tuple are accessed by name.

With this PR I make sure that the dimensions of the DataFrame object are reduced to the necessary amount (which is < 255) before iterating over them. Additionally, a small compatibility problem between `codecs` and `Path` is fixed.