### PR TITLE
FIX: correctly check for type of debugging_mode parameter

### DIFF
--- a/evaluation_framework/manager.py
+++ b/evaluation_framework/manager.py
@@ -178,7 +178,7 @@ class FrameworkManager:
 
         # compare_with TODO
 
-        if self.debugging_mode is not True and self.debugging_mode is False:
+        if type(self.debugging_mode) is not bool:
             raise Exception("The parameter DEBUGGING_MODE is boolean.")
 
     """


### PR DESCRIPTION
Fixing invalid error that is thrown when setting debugging_mode to False.